### PR TITLE
Make Choice selects among its candidates to mutate.

### DIFF
--- a/Peach.Core/Dom/Choice.cs
+++ b/Peach.Core/Dom/Choice.cs
@@ -67,6 +67,7 @@ namespace Peach.Core.Dom
 		static NLog.Logger logger = LogManager.GetCurrentClassLogger();
 		public OrderedDictionary<string, DataElement> choiceElements = new OrderedDictionary<string, DataElement>();
 		DataElement _selectedElement = null;
+		static Random random = new Random((uint)Environment.TickCount);
 
 		public Choice()
 		{
@@ -114,7 +115,7 @@ namespace Peach.Core.Dom
 		public void SelectDefault()
 		{
 			Clear();
-			this.Add(choiceElements[0]);
+			this.Add(random.Choice(choiceElements).Value);
 			_selectedElement = this[0];
 		}
 


### PR DESCRIPTION
方案：
在`Choice`被获取数据时，`SelectDefault()`被调用并设置`_selectedElement`为`choiceElements`中第一个元素。所以添加随机取值，这里复用`Random`，但仅将`Random`设置成静态成员来节省初始化过程的耗时（会导致每轮中Choice取值规律相同，可替换为其他随机函数或不设置`Random`为静态成员来规避）。

测试：
样例规则：
```xml
<?xml version="1.0" encoding="utf-8"?>
<Peach xmlns="http://peachfuzzer.com/2012/Peach" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
xsi:schemaLocation="http://peachfuzzer.com/2012/Peach ../peach.xsd">

<DataModel name="HelloWorldTemplate">
	<Choice name="Choice1" minOccurs="20" maxOccurs="100">
		<String value="Hello World1!"/>
		<String value="Hello World2!"/>
		<String value="Hello World3!"/>
	</Choice>
</DataModel>

<StateModel name="State" initialState="State1">
	<State name="State1">
		<Action type="output">
			<DataModel ref="HelloWorldTemplate"/>
		</Action>
	</State>
</StateModel>

<Test name="Default">
	<StateModel ref="State"/>
		<Publisher class="stdout.Stdout"/>
	</Test>
</Peach>
```

生成数据：
```bash
[7,-,-] Performing iteration
[*] Fuzzing: HelloWorldTemplate.Choice1.Choice1_2
[*] Mutator: DataElementSwapNearNodesMutator
[*] Fuzzing: HelloWorldTemplate.Choice1.Choice1_5
[*] Mutator: DataElementSwapNearNodesMutator
[*] Fuzzing: HelloWorldTemplate.Choice1.Choice1_1
[*] Mutator: DataElementSwapNearNodesMutator
[*] Fuzzing: HelloWorldTemplate.Choice1.Choice1_3.DataElement_1
[*] Mutator: DataElementDuplicateMutator
Hello World1!Hello World2!Hello World1!Hello World2!Hello World3!Hello World3!Hello World1!Hello World2!Hello World3!Hello World2!Hello World2!Hello World3!Hello World2!Hello World2!Hello World3!Hello World3!Hello World3!Hello World1!Hello World3!Hello World2!
```
